### PR TITLE
Fix for ReadableStream body becoming locked

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titelmedia/node-fetch",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": false,
   "description": "A light-weight module that brings the Fetch API to node.js; Forked from https://npm.im/node-fetch",
   "main": "lib/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@titelmedia/node-fetch",
   "version": "3.0.0",
+  "private": false,
   "description": "A light-weight module that brings the Fetch API to node.js; Forked from https://npm.im/node-fetch",
   "main": "lib/index",
   "module": "lib/index.mjs",

--- a/src/body.js
+++ b/src/body.js
@@ -177,7 +177,12 @@ export default function Body(body, {
 		name
 	};
 
-	this[INTERNALS].readableStream = createReadableStream(this)
+	const bodyType = getTypeOfBody(body);
+	if (bodyType !== 'ReadableStream') {
+		this[INTERNALS].readableStream = createReadableStream(this);
+	} else {
+		this[INTERNALS].readableStream = body;
+	}
 }
 
 Body.prototype = {


### PR DESCRIPTION
When creating a new Request or Response with a body of type "ReadableStream", it would become locked due to unnecessarily creating a new ReadableStream via a TransformStream.

This PR fixes that by using the original ReadableStream (as passed into the Response/Request constructors). 